### PR TITLE
Rename param to defer-days, add reporting for deferred containers, general simplifications

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -381,12 +381,12 @@ Environment Variable: WATCHTOWER_HTTP_API_METRICS
              Default: false
 ```
 
-## Delayed Update
+## Deferred Update
 Only update container to latest version of image if some number of days have passed since it has been published. This option may be useful for those who wish to avoid updating prior to the new version having some time in the field prior to updating in case there are critical defects found and released in a subsequent version.
 
 ```text
-            Argument: --delay-days
-Environment Variable: WATCHTOWER_DELAY_DAYS
+            Argument: --defer-days
+Environment Variable: WATCHTOWER_DEFER_DAYS
                 Type: Integer
              Default: false
 ```

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -82,7 +82,7 @@ func CreateMockContainerWithDigest(id string, name string, image string, created
 // CreateMockContainerWithDigest should only be used for testing
 func CreateMockContainerWithImageCreatedTime(id string, name string, image string, created time.Time, imageCreated time.Time) wt.Container {
 	c := CreateMockContainer(id, name, image, created)
-	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339)
+	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339Nano)
 	return c
 }
 

--- a/internal/actions/mocks/container.go
+++ b/internal/actions/mocks/container.go
@@ -79,6 +79,13 @@ func CreateMockContainerWithDigest(id string, name string, image string, created
 	return c
 }
 
+// CreateMockContainerWithDigest should only be used for testing
+func CreateMockContainerWithImageCreatedTime(id string, name string, image string, created time.Time, imageCreated time.Time) wt.Container {
+	c := CreateMockContainer(id, name, image, created)
+	c.ImageInfo().Created = imageCreated.UTC().Format(time.RFC3339)
+	return c
+}
+
 // CreateMockContainerWithConfig creates a container substitute valid for testing
 func CreateMockContainerWithConfig(id string, name string, image string, running bool, restarting bool, created time.Time, config *dockerContainer.Config) wt.Container {
 	content := types.ContainerJSON{

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -148,9 +148,9 @@ func RegisterSystemFlags(rootCmd *cobra.Command) {
 		"Enable the execution of commands triggered by pre- and post-update lifecycle hooks")
 
 	flags.IntP(
-		"delay-days",
+		"defer-days",
 		"0",
-		envInt("WATCHTOWER_DELAY_DAYS"),
+		envInt("WATCHTOWER_DEFER_DAYS"),
 		"Number of days to wait for new image version to be in place prior to installing it")
 
 	flags.BoolP(

--- a/pkg/notifications/json.go
+++ b/pkg/notifications/json.go
@@ -23,12 +23,13 @@ func (d Data) MarshalJSON() ([]byte, error) {
 	var report jsonMap
 	if d.Report != nil {
 		report = jsonMap{
-			`scanned`: marshalReports(d.Report.Scanned()),
-			`updated`: marshalReports(d.Report.Updated()),
-			`failed`:  marshalReports(d.Report.Failed()),
-			`skipped`: marshalReports(d.Report.Skipped()),
-			`stale`:   marshalReports(d.Report.Stale()),
-			`fresh`:   marshalReports(d.Report.Fresh()),
+			`scanned`:  marshalReports(d.Report.Scanned()),
+			`updated`:  marshalReports(d.Report.Updated()),
+			`deferred`: marshalReports(d.Report.Deferred()),
+			`failed`:   marshalReports(d.Report.Failed()),
+			`skipped`:  marshalReports(d.Report.Skipped()),
+			`stale`:    marshalReports(d.Report.Stale()),
+			`fresh`:    marshalReports(d.Report.Fresh()),
 		}
 	}
 

--- a/pkg/notifications/json_test.go
+++ b/pkg/notifications/json_test.go
@@ -21,6 +21,7 @@ var _ = Describe("JSON template", func() {
 		],
 		"host": "Mock",
 		"report": {
+		"deferred": [],
 		"failed": [
 			{
 				"currentImageId": "01d210000000",
@@ -110,7 +111,7 @@ var _ = Describe("JSON template", func() {
 		},
 		"title": "Watchtower updates on Mock"
 }`
-				data := mockDataFromStates(s.UpdatedState, s.FreshState, s.FailedState, s.SkippedState, s.UpdatedState)
+				data := mockDataFromStates(s.UpdatedState, s.DeferredState, s.FreshState, s.FailedState, s.SkippedState, s.UpdatedState)
 				Expect(getTemplatedResult(`json.v1`, false, data)).To(MatchJSON(expected))
 			})
 		})

--- a/pkg/notifications/preview/data/data.go
+++ b/pkg/notifications/preview/data/data.go
@@ -72,6 +72,8 @@ func (pb *previewData) addContainer(c containerStatus) {
 		pb.report.scanned = append(pb.report.scanned, &c)
 	case UpdatedState:
 		pb.report.updated = append(pb.report.updated, &c)
+	case DeferredState:
+		pb.report.deferred = append(pb.report.deferred, &c)
 	case FailedState:
 		pb.report.failed = append(pb.report.failed, &c)
 	case SkippedState:

--- a/pkg/notifications/preview/data/report.go
+++ b/pkg/notifications/preview/data/report.go
@@ -10,12 +10,13 @@ import (
 type State string
 
 const (
-	ScannedState State = "scanned"
-	UpdatedState State = "updated"
-	FailedState  State = "failed"
-	SkippedState State = "skipped"
-	StaleState   State = "stale"
-	FreshState   State = "fresh"
+	ScannedState  State = "scanned"
+	UpdatedState  State = "updated"
+	DeferredState State = "deferred"
+	FailedState   State = "failed"
+	SkippedState  State = "skipped"
+	StaleState    State = "stale"
+	FreshState    State = "fresh"
 )
 
 // StatesFromString parses a string of state characters and returns a slice of the corresponding report states
@@ -27,6 +28,8 @@ func StatesFromString(str string) []State {
 			states = append(states, ScannedState)
 		case 'u':
 			states = append(states, UpdatedState)
+		case 'd':
+			states = append(states, DeferredState)
 		case 'e':
 			states = append(states, FailedState)
 		case 'k':
@@ -43,12 +46,13 @@ func StatesFromString(str string) []State {
 }
 
 type report struct {
-	scanned []types.ContainerReport
-	updated []types.ContainerReport
-	failed  []types.ContainerReport
-	skipped []types.ContainerReport
-	stale   []types.ContainerReport
-	fresh   []types.ContainerReport
+	scanned  []types.ContainerReport
+	updated  []types.ContainerReport
+	deferred []types.ContainerReport
+	failed   []types.ContainerReport
+	skipped  []types.ContainerReport
+	stale    []types.ContainerReport
+	fresh    []types.ContainerReport
 }
 
 func (r *report) Scanned() []types.ContainerReport {
@@ -56,6 +60,9 @@ func (r *report) Scanned() []types.ContainerReport {
 }
 func (r *report) Updated() []types.ContainerReport {
 	return r.updated
+}
+func (r *report) Deferred() []types.ContainerReport {
+	return r.deferred
 }
 func (r *report) Failed() []types.ContainerReport {
 	return r.failed
@@ -87,6 +94,7 @@ func (r *report) All() []types.ContainerReport {
 	}
 
 	appendUnique(r.updated)
+	appendUnique(r.deferred)
 	appendUnique(r.failed)
 	appendUnique(r.skipped)
 	appendUnique(r.stale)

--- a/pkg/session/container_status.go
+++ b/pkg/session/container_status.go
@@ -12,6 +12,7 @@ const (
 	SkippedState
 	ScannedState
 	UpdatedState
+	DeferredState
 	FailedState
 	FreshState
 	StaleState
@@ -70,6 +71,8 @@ func (u *ContainerStatus) State() string {
 		return "Scanned"
 	case UpdatedState:
 		return "Updated"
+	case DeferredState:
+		return "Deferred"
 	case FailedState:
 		return "Failed"
 	case FreshState:

--- a/pkg/session/progress.go
+++ b/pkg/session/progress.go
@@ -50,6 +50,11 @@ func (m Progress) MarkForUpdate(containerID types.ContainerID) {
 	m[containerID].state = UpdatedState
 }
 
+// MarkForUpdate marks the container identified by containerID for deferral
+func (m Progress) MarkDeferred(containerID types.ContainerID) {
+	m[containerID].state = DeferredState
+}
+
 // Report creates a new Report from a Progress instance
 func (m Progress) Report() types.Report {
 	return NewReport(m)

--- a/pkg/types/report.go
+++ b/pkg/types/report.go
@@ -4,6 +4,7 @@ package types
 type Report interface {
 	Scanned() []ContainerReport
 	Updated() []ContainerReport
+	Deferred() []ContainerReport
 	Failed() []ContainerReport
 	Skipped() []ContainerReport
 	Stale() []ContainerReport

--- a/pkg/types/update_params.go
+++ b/pkg/types/update_params.go
@@ -12,7 +12,7 @@ type UpdateParams struct {
 	Timeout         time.Duration
 	MonitorOnly     bool
 	NoPull          bool
-	DelayDays       int
+	DeferDays       int
 	LifecycleHooks  bool
 	RollingRestart  bool
 	LabelPrecedence bool

--- a/tplprev/main.go
+++ b/tplprev/main.go
@@ -18,7 +18,7 @@ func main() {
 	var states string
 	var entries string
 
-	flag.StringVar(&states, "states", "cccuuueeekkktttfff", "sCanned, Updated, failEd, sKipped, sTale, Fresh")
+	flag.StringVar(&states, "states", "cccuuudddeeekkktttfff", "sCanned, Updated, Deferred, failEd, sKipped, sTale, Fresh")
 	flag.StringVar(&entries, "entries", "ewwiiidddd", "Fatal,Error,Warn,Info,Debug,Trace")
 
 	flag.Parse()


### PR DESCRIPTION
This update makes the following changes:

- Renamed parameter from delay-days to defer-days for better clarity in reporting
- Added reporting on number of containers that were deferred to eliminate any confusion about why items in Scanned count weren't in Updated count
- Simplified login in update process for readability and maintainability
- Fix problem where deferred items were reported as updated when they weren't
- Added unit test cases to test defer functionality 

These changes are in anticipation of https://github.com/containrrr/watchtower/pull/1895 in the main repo and are aligned with that new logic.